### PR TITLE
Add .NET Core SDK devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,12 @@
     "image": "mcr.microsoft.com/dotnet/core/sdk:3.1",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
     "workspaceFolder": "/workspace",
-    "extensions": [
-        "ms-dotnettools.csharp",
-        "ms-vscode.vscode-node-azure-pack"
-    ]
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "ms-vscode.vscode-node-azure-pack"
+            ]
+        }
+    }
 }

--- a/Adapter/.devcontainer/devcontainer.json
+++ b/Adapter/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "C# Dev Container",
+    "image": "mcr.microsoft.com/dotnet/core/sdk:3.1",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace",
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-vscode.vscode-node-azure-pack"
+    ]
+}


### PR DESCRIPTION
This pull request adds a devcontainer configuration for .NET Core SDK 3.1. It includes a `.devcontainer` directory with a `devcontainer.json` file that specifies the use of the `mcr.microsoft.com/dotnet/core/sdk:3.1` Docker image. The configuration also includes settings for mounting the workspace and installs necessary extensions for .NET Core development. For more details, please refer to the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dedac/csharp-design-patterns-2314072?shareId=XXXX-XXXX-XXXX-XXXX).